### PR TITLE
GHA: use node LTS on runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
-      with:
-        node-version: 16.x
 
     - name: Install dependencies
       run: yarn install

--- a/.github/workflows/gh-pages-main.yml
+++ b/.github/workflows/gh-pages-main.yml
@@ -16,10 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-
       - uses: actions/setup-node@v4
-        with:
-          node-version: 16.x
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -20,10 +20,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
-        with:
-          node-version: 16.x
 
       - name: Install and Build
         run: |


### PR DESCRIPTION
removing version defaults to running LTS.