### PR TITLE
WEBDEV-7347 Update codecov configuration and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,6 @@ jobs:
     - name: Run tests
       run: yarn run test
 
-    - name: Upload reports
-      run: npx codecov
+    - uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a base template for creating Typescript WebComponents. It is based off o
 3. `README.md` (this file). Update the readme in general, but also the badge URLs
 4. `package.json` Update the name and description
 5. Rename the `your-webcomponent.ts` and its associated `.test` file
-6. Enable `renovate` in the GitHub Apps section if not already enabled
+6. Enable `Codecov` and `renovate` in the GitHub Apps section if not already enabled (be sure not to enable `pre-commit`)
 7. Set up a Codecov token (see [Codecov Setup](#codecov-setup))
 
 ## Local Demo with `web-dev-server`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build Status](https://github.com/internetarchive/iaux-typescript-wc-template/actions/workflows/ci.yml/badge.svg) [![codecov](https://codecov.io/gh/internetarchive/iaux-typescript-wc-template/branch/main/graph/badge.svg?token=ZOYRJ2BV9W)](https://codecov.io/gh/internetarchive/iaux-typescript-wc-template)
+![Build Status](https://github.com/internetarchive/iaux-typescript-wc-template/actions/workflows/ci.yml/badge.svg) [![codecov](https://codecov.io/gh/internetarchive/iaux-typescript-wc-template/graph/badge.svg?token=ZOYRJ2BV9W)](https://codecov.io/gh/internetarchive/iaux-typescript-wc-template)
 
 # Internet Archive Typescript WebComponent Template
 
@@ -15,6 +15,8 @@ This is a base template for creating Typescript WebComponents. It is based off o
 3. `README.md` (this file). Update the readme in general, but also the badge URLs
 4. `package.json` Update the name and description
 5. Rename the `your-webcomponent.ts` and its associated `.test` file
+6. Enable `renovate` in the GitHub Apps section if not already enabled
+7. Set up a Codecov token (see [Codecov Setup](#codecov-setup))
 
 ## Local Demo with `web-dev-server`
 ```bash
@@ -85,10 +87,24 @@ For most of the tools, the configuration is in the `package.json` to reduce the 
 
 If you customize the configuration a lot, you can consider moving them to individual files.
 
-### Add Codecov
-- after forking, add your repo to the authorized codecov list: `https://github.com/organizations/internetarchive/settings/installations/1268216`
-- then, go to the badge maker page for your repo: `https://app.codecov.io/gh/internetarchive/<repo-name>/settings/badge`
-- copy link & paste into top of README.md
+### Codecov setup
+**Finding your token**
+- Log in at https://codecov.io/ with your GitHub account
+- Switch from your personal organization to `internetarchive` if needed, by toggling at the top of the screen or visiting https://app.codecov.io/gh/internetarchive directly
+- Find your repository and hit the `Configure` button or visit `https://app.codecov.io/gh/internetarchive/YOUR-REPO-NAME/config`
+- Go the `General` tab and find the `Tokens` section
+- Copy everything after `CODECOV_TOKEN=`
+
+**Adding your token**
+- Return to your repository and go to `Settings` > `Secrets and variables` (under `Security`) > `Actions`
+- Select `New repository secret`
+- Name your secret `CODECOV_TOKEN` and paste in the token you just copied
+- Select `Add Secret`
+
+**Adding your badge**
+- Back in `Configuration` in Codecov, go to the `Badges & Graphs` section
+- Copy the Markdown version of the badge
+- Delete the current Codecov badge at the top of this README and replace it with your new badge
 
 ## Steps to setup `gh-pages` static site generator
 


### PR DESCRIPTION
Switches out the Codecov configuration to the supported token-based standard, and updates the docs with current instructions re: how to set up a token.