### PR TITLE
WEBDEV-7368 Add coverage and recommended extensions to template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/tasks.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+    "recommendations": [
+      "dbaeumer.vscode-eslint",
+      "esbenp.prettier-vscode",
+      "bierner.lit-html",
+      "bashmish.es6-string-css",
+      "streetsidesoftware.code-spell-checker",
+      "runem.lit-plugin",
+      "ryanluker.vscode-coverage-gutters"
+    ]
+  }
+  

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Watch coverage on open",
+            "command": "${command:coverage-gutters.watchCoverageAndVisibleEditors}",
+            "runOptions": {
+                "runOn": "folderOpen"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Adds coverage script to `tasks.json` and recommended extensions `extensions.json` for VSCode.