### PR TITLE
Add gitignore for coverage

### DIFF
--- a/coverage/.gitignore
+++ b/coverage/.gitignore
@@ -1,0 +1,3 @@
+*
+!.placeholder
+!.gitignore


### PR DESCRIPTION
Prevents the `.gitignore` file in `/coverage` from ignoring itself so that everything generated from the template will not attempt to upload coverage to git.