### PR TITLE
WEBDEV-7497: Remove spell checker from suggested extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,9 +4,7 @@
       "esbenp.prettier-vscode",
       "bierner.lit-html",
       "bashmish.es6-string-css",
-      "streetsidesoftware.code-spell-checker",
       "runem.lit-plugin",
       "ryanluker.vscode-coverage-gutters"
     ]
   }
-  


### PR DESCRIPTION
The spell checker can be kind of noisy so let's not add it by default