### PR TITLE
Add dom.iterable to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017", "dom", "dom.iterable"],
     "strict": true,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
The browsers that we target have all long supported DOM iteration with methods like `querySelectorAll`. This PR just adds `dom.iterable` to our tsconfig so that any repos cloned from this template will not need to add it themselves just to make use of those methods without running into type errors.