### PR TITLE
WEBDEV-8818: Run App CI on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: App CI
 on:
   push:
     branches: [ main ]
+  # every pull request, whatever it targets, so a PR stacked on another
+  # branch still gets its tests run
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
## What

Drops the branch filter from the `pull_request` trigger so App CI runs on every PR, not only PRs targeting `main`.

```diff
   push:
     branches: [ main ]
+  # every pull request, whatever it targets, so a PR stacked on another
+  # branch still gets its tests run
   pull_request:
-    branches: [ main ]
```

The `push` filter is left alone, that one is doing its job.

## Why

A PR stacked on another branch currently gets **no test run at all**, and GitHub still shows it green because the preview-deploy workflow has no such filter and passes. So the PR reads as checked when nothing ran.

This bit twice in one afternoon on other repos: a 1400-line model change and a component migration, both showing green with no test run.

This repo is first in the sweep because new component repos are scaffolded from it, so until it's fixed the problem keeps arriving in new repos.

## Test plan

CI on this PR is itself the check: it targets `main`, so it runs either way. The behaviour it fixes only shows on a PR that targets something else, which is what the rest of [WEBDEV-8818](https://webarchive.jira.com/browse/WEBDEV-8818) covers per repo.

No test, build, or publish behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEBDEV-8818]: https://webarchive.jira.com/browse/WEBDEV-8818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ